### PR TITLE
Use yay without sudo

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -39,7 +39,7 @@ install_deps() {
     grep -E 'depends|makedepends' PKGBUILD | \
         sed -e 's/.*depends=//' -e 's/ /\n/g' | \
         tr -d "'" | tr -d "(" | tr -d ")" | \
-        xargs sudo yay -S --noconfirm
+        xargs yay -S --noconfirm
 }
 
 case $target in


### PR DESCRIPTION
Otherwise it fails with
```
==> Refusing to install AUR Packages as root, Aborting.
```
when building https://github.com/2m/ucm-bin-pkgbuild/pull/10

@gr211 what was the usecase where you needed to run yay with `sudo`?