### PR TITLE
Use PKGEXT in /etc/makepkg.conf

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -51,8 +51,9 @@ case $target in
         install_deps
         makepkg --syncdeps --noconfirm
         namcap "${pkgname}"-*
-        pacman -Qip "${pkgname}"-*.xz
-        pacman -Qlp "${pkgname}"-*.xz
+        source /etc/makepkg.conf # get PKGEXT
+        pacman -Qip "${pkgname}"-*"${PKGEXT}"
+        pacman -Qlp "${pkgname}"-*"${PKGEXT}"
         ;;
     run)
         install_deps


### PR DESCRIPTION
[It failed](https://github.com/cpeditor/cpeditor/actions/runs/194190066) because the `PKGEXT` was not `.pkg.tar.xz`. This PR fixes it.