### PR TITLE
Use more reliable keyserver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+---
+name: ci
+
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  validation:
+    runs-on: ubuntu-latest
+    name: Validate a Pull Request
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Run yamllint
+        uses: ibiqlik/action-yamllint@v1.0.0
+
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,6 +1,6 @@
 name: Release Drafter
 
-on:
+on:  # yamllint disable-line rule:truthy
   push:
     branches:
       - master

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,6 @@
+---
+extends: default
+
+rules:
+  # Disable requirement for `---` at the beginning of each file
+  document-start: disable

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ This assumption is made so this action works well with [aurpublish].
 
 ### `pkgname`
 
-**Required** The `pkgname` of the package to be validated.
+**Required** Path to DIRECTORY where the PKGBUILD file is.
+Assumes the directory is the name of package, ie /path/to/pkgname/'
 
 ## Example usage
 

--- a/action.yml
+++ b/action.yml
@@ -1,28 +1,34 @@
-name: 'Arch Linux PKGBUILD builder action'
-description: 'Builds an validates PKGBUILD definition'
+name: Arch Linux PKGBUILD builder action
+description: Builds an validates PKGBUILD definition
 
 branding:
-  icon: 'triangle'
-  color: 'blue'
+  icon: triangle
+  color: blue
 
 inputs:
   pkgname:
-    description: 'Path to DIRECTORY where the PKGBUILD file is. Assumes the directory is the name of package, ie /path/to/pkgname/'
+    description: >-
+      Path to DIRECTORY where the PKGBUILD file is.
+      Assumes the directory is the name of package, ie /path/to/pkgname/
     required: true
   target:
-    description: 'Validation target. Can be one of: "pkgbuild", "srcinfo"'
+    description: >-
+      Validation target.
+      Can be one of: "pkgbuild", "srcinfo", "run"
     required: true
     default: 'pkgbuild'
   command:
-    description: 'Command to run after package installation'
+    description: >-
+      Command to run after package installation.
+      Used when target=run
     required: false
   debug:
-    description: 'Turns debugging on'
+    description: Turns debugging on
     required: false
 
 runs:
-  using: 'docker'
-  image: 'Dockerfile'
+  using: docker
+  image: Dockerfile
   args:
     - ${{ inputs.target }}
     - ${{ inputs.pkgname }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,6 @@
 #!/bin/sh -l
 
+# fail whole script if any command fails
 set -e
 
 DEBUG=$4

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,6 +38,10 @@ sudo chown -R build "$pkgbuild_dir"
 # needs permissions so '/github/home/.config/yay' is accessible by yay
 sudo chown -R build /github/home
 
+# use more reliable keyserver
+mkdir -p /github/home/.gnupg/
+echo "keyserver hkp://keyserver.ubuntu.com:80" | tee /github/home/.gnupg/gpg.conf
+
 cd "$pkgbuild_dir"
 
 pkgname="$(basename "$pkgbuild_dir")" # keep quotes in case someone passes in a directory path with whitespaces...

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -l
+#!/bin/bash
 
 # fail whole script if any command fails
 set -e
@@ -27,20 +27,20 @@ if [[ ! -e $pkgname/PKGBUILD ]]; then
     exit 1
 fi
 
-pkgbuild_dir=$(readlink $pkgname -f) # nicely cleans up path, ie. ///dsq/dqsdsq/my-package//// -> /dsq/dqsdsq/my-package
+pkgbuild_dir=$(readlink "$pkgname" -f) # nicely cleans up path, ie. ///dsq/dqsdsq/my-package//// -> /dsq/dqsdsq/my-package
 
 getfacl -p -R "$pkgbuild_dir" /github/home > /tmp/arch-pkgbuild-builder-permissions.bak
 
 # '/github/workspace' is mounted as a volume and has owner set to root
 # set the owner of $pkgbuild_dir  to the 'build' user, so it can access package files.
-sudo chown -R build $pkgbuild_dir
+sudo chown -R build "$pkgbuild_dir"
 
 # needs permissions so '/github/home/.config/yay' is accessible by yay
 sudo chown -R build /github/home
 
-cd $pkgbuild_dir
+cd "$pkgbuild_dir"
 
-pkgname="$(basename $pkgbuild_dir)" # keep quotes in case someone passes in a directory path with whitespaces...
+pkgname="$(basename "$pkgbuild_dir")" # keep quotes in case someone passes in a directory path with whitespaces...
 
 install_deps() {
     # install make and regular package dependencies
@@ -56,7 +56,10 @@ case $target in
         install_deps
         makepkg --syncdeps --noconfirm
         namcap "${pkgname}"-*
+
+        # shellcheck disable=SC1091
         source /etc/makepkg.conf # get PKGEXT
+
         pacman -Qip "${pkgname}"-*"${PKGEXT}"
         pacman -Qlp "${pkgname}"-*"${PKGEXT}"
         ;;


### PR DESCRIPTION
With the default keyserver the following error happens when `yay` is trying to import keys:

```
:: Importing keys with gpg...
gpg: keyserver receive failed: General error
problem importing keys
```