### PR TITLE
Make dependency parsing more strict

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -53,7 +53,7 @@ pkgname=$(grep -E 'pkgname' .SRCINFO | sed -e 's/.*= //')
 
 install_deps() {
     # install all package dependencies
-    grep -E 'depends' .SRCINFO | \
+    grep -E 'depends =' .SRCINFO | \
         sed -e 's/.*depends = //' -e 's/:.*//' | \
         xargs yay -S --noconfirm --needed
 }


### PR DESCRIPTION
So it does not take lines in the package description that mentions `depends`.

Fixes #46